### PR TITLE
feat:Add counting animations for stats

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -23,22 +23,22 @@ const SocialMediaIcon = ({ Icon, href }) => (
 export default function Home() {
   const statisticsData = [
     {
-      number: "1500+",
+      number: 1500,
       label: "Registrations",
       description: "1500+ registrations from across the country.",
     },
     {
-      number: "500+",
+      number: 500,
       label: "Offline Participants",
       description: "500+ participants joined the offline hackathon!",
     },
     {
-      number: "100+",
+      number: 100,
       label: "Volunteers",
       description: "To help you, get the best out of HackByte.",
     },
     {
-      number: "120+",
+      number: 120,
       label: "Projects",
       description: "Innovative submissions from various domains.",
     },

--- a/components/CountAnimation/index.jsx
+++ b/components/CountAnimation/index.jsx
@@ -1,31 +1,61 @@
 "use client";
 import { motion, useMotionValue, useTransform, animate } from "framer-motion";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export default function CountAnimation({ targetValue }) {
   const count = useMotionValue(0);
   const rounded = useTransform(count, Math.round);
 
+  const ref = useRef();
+
   useEffect(() => {
-    const animation = animate(count, targetValue, {
-      duration: 1,
-      ease: "linear",
-      onUpdate: (latest) => count.set(latest),
-    });
-    return animation.stop;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          const animation = animate(count, targetValue, {
+            duration: 1,
+            ease: "linear",
+            onUpdate: (latest) => count.set(latest),
+          });
+        }
+      },
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold: 1
+      }
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
   }, []);
 
+  const styles = {
+    background:
+      "linear-gradient(80deg, #D06D30 6.67%, #FFD887 28.13%, #FFDCAD 64.87%, #FAB858 95.66%)",
+    backgroundClip: "text",
+    WebkitBackgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+  };
+
   return (
-    <div className="flex">
+    <div ref={ref} className="flex">
       <motion.p
-        className="self-stretch text-center text-white text-5xl md:text-3xl 
-        lg:text-[3.25rem] xl:text-6xl font-semibold font-['Inter'] leading-[72px]"
+        className="font-medium text-[3rem] md:text-[4rem] leading-[3rem]"
+        style={styles}
       >
         {rounded}
       </motion.p>
       <p
-        className="self-stretch text-center text-white text-5xl md:text-3xl 
-        lg:text-[3.25rem] xl:text-6xl font-semibold font-['Inter'] leading-[72px]"
+        className="font-medium text-[3rem] md:text-[4rem] leading-[3rem]"
+        style={styles}
       >
         +
       </p>

--- a/components/StatisticCard/index.jsx
+++ b/components/StatisticCard/index.jsx
@@ -1,18 +1,9 @@
+import CountAnimation from "../CountAnimation";
+
 export default function StatisticCard({ number, label, description }) {
   return (
     <div className="flex flex-col items-center gap-4">
-      <p
-        className="font-medium text-[3rem] md:text-[4rem] leading-[3rem]"
-        style={{
-          background:
-            "linear-gradient(80deg, #D06D30 6.67%, #FFD887 28.13%, #FFDCAD 64.87%, #FAB858 95.66%)",
-          backgroundClip: "text",
-          WebkitBackgroundClip: "text",
-          WebkitTextFillColor: "transparent",
-        }}
-      >
-        {number}
-      </p>
+      <CountAnimation targetValue={number} />
       <div className="flex flex-col items-center gap-1">
         <p className="text-[#F5F0D8] font-medium text-[1.5rem] md:text-[1.875rem]">
           {label}


### PR DESCRIPTION
This PR adds the following:
 Counting Animation for the statistical numbers in the home page. The animation is visible when the user scroll the 'stats' into view for 1st time.
